### PR TITLE
[#15] Support invocation from subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
-#
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -22,3 +19,6 @@ bin
 
 # Go workspace file
 go.work
+
+# Developer tools configs
+.vscode

--- a/cmd/commit/main.go
+++ b/cmd/commit/main.go
@@ -41,7 +41,12 @@ func main() {
 	repo := openRepo()
 	worktree := openWorktree(repo)
 
-	configFilePath = filepath.Join(worktree.Filesystem.Root(), helpers.DEFAULT_CONFIG_FILE_PATH)
+	if configFilePath == "" {
+		configFilePath = filepath.Join(
+			worktree.Filesystem.Root(),
+			helpers.DEFAULT_CONFIG_FILE_PATH,
+		)
+	}
 
 	headRef := getCurrentHead(repo)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,5 +87,5 @@ Originally I wrote this tool for myself in shell and Swift and used a lot on Mac
 If you find it useful and see that something's wrong or missing, feel free to raise issues and contribute to the project.  
 When doing so, please follow the ususal code of conduct and contribution guidelines from GitHub, and just common sense.
 ## License
-This repository is distributed under the MIT license (see [LICENSE.md](/docs/LICENSE.md).  
+This repository is distributed under the MIT license (see [LICENSE.md](/docs/LICENSE)).  
 My tool uses [go-git](https://github.com/go-git/go-git) as a 3rd party dependency to work with git directly, you might want to check it out too.


### PR DESCRIPTION
In this PR:
- made sure the tool finds the repository from its subdirectory
- made the tool search for the config in the root of the repository if current folder is a subdirectory
- ignored the `.vscode` folder
- fixed a link to the license file in README

closes #15 

