### PR TITLE
Add end-to-end tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.22'
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,4 +22,4 @@ jobs:
       run: make test
     
     - name: Run End-to-End Tests
-      run: sh e2e.sh
+      run: /usr/bin/sh e2e.sh

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,4 +22,5 @@ jobs:
       run: make test
     
     - name: Run End-to-End Tests
-      run: /usr/bin/sh e2e.sh
+      shell: sh
+      run: sh e2e.sh

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,5 +18,8 @@ jobs:
       with:
         go-version: '1.22'
 
-    - name: Test
+    - name: Run Unit Tests
       run: make test
+    
+    - name: Run End-to-End Tests
+      run: sh e2e.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,20 @@
-# Build the current machine
+# Build for the current machine
 .PHONY: build
 build:
 	@go build -o bin/ ./cmd/commit/
+
+# Build and install
+.PHONY: install
+install:
+	@INSTALLATION_PATH=$$(which commit) ; \
+	if [ -z "$${INSTALLATION_PATH}" ]; then \
+		go install -ldflags "-s -w" ./cmd/commit/ ; \
+	else \
+		go build -ldflags "-s -w" -o bin/ ./cmd/commit ; \
+		INSTALLATION_DIR=$$(dirname "$${INSTALLATION_PATH}") ; \
+		mv bin/commit $${INSTALLATION_DIR} ; \
+	fi && \
+	echo "Installed at $${INSTALLATION_PATH}"
 
 # Build for all platforms
 .PHONY: all

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 Simple CLI tool that finds an issue number in the branch and includes it in the commit message.
 
 ## Installation
-### Using Pre-built Executable
+### Install Pre-built Executable
 1. In the [Releases](https://github.com/artem-y/commit/releases) section, find and open the latest release (or any other one if you want).
 2. Download `bin.zip` archive
 3. Unarchive it and find a folder for your machine's architecture.
@@ -13,7 +13,7 @@ Simple CLI tool that finds an issue number in the branch and includes it in the 
    ```shell
    alias commit="commit -config-path=${HOME}/.config/.commit.json"
    ```
-### Using Makefile
+### Install With Makefile
 1. Make sure you have a compatible version of `Go` installed _(see [go.mod](https://github.com/artem-y/commit/blob/main/go.mod#L3) file)_
 2. Clone the repository
 3. In the root of the repository, run `make build` command
@@ -25,11 +25,27 @@ Simple CLI tool that finds an issue number in the branch and includes it in the 
    ```  
 
 Check out the [Makefile](/Makefile) for more commands.
-### Using Go Tooling
-You can do the steps described above in the [Using Makefile](#using-makefile) section, replacing Step 3 (`make build` command) with just a plain Go build command:  
+
+### Easy Installation With Makefile
+There's a helper command in that can simplify installation:
+```shell
+make install
+```
+1. Make sure you have a compatible version of `Go` installed _(see [go.mod](https://github.com/artem-y/commit/blob/main/go.mod#L3) file)_
+2. Clone the repository
+3. In the root of the repository, run `make install`
+4. (Optional) It will try to install to where it was installed previously. In case this is the first installation, it will be installed in the default Go package directory. If the tool is not visible after instllation, make sure it's directory is included in `PATH`.
+
+### Install With Go Tooling
+You can do the steps described above in the [Using Makefile](#install-with-makefile) section, replacing Step 3 (`make build` command) with just a plain Go build command:  
 ```shell
 go build -o bin/ ./cmd/commit
 ```
+Or you can skip even those steps and use `go install` command:
+```shell
+go install -ldflags "-s -w" ./cmd/commit
+```
+This will install the executable in the default Go package directory. If the tool is not visible after the installation, make sure it's directory is included in `PATH`.
 
 For more information, see [Tutorial: Compile and install the application](https://go.dev/doc/tutorial/compile-install) 
 ## Usage
@@ -76,7 +92,8 @@ For example, the branch named `add-tests-for-CR-127-and-CR-131-features`, the is
 > [CR-127, CR-131]:
 ## Testing
 So far only the core parts of the logic are covered with tests, but I will be adding more in the future.  
-To run the tests, use the `make test` or `go test -v ./...` commands.
+To run the unit tests, use the `make test` or `go test -v ./...` commands.  
+There also are a few end-to-end tests that will run in the CI pipeline to make sure the tool actually works as expected with a real repository. I do not advise running those often manually, since they can potentially execute destructive commands.
 ### Debug
 To check what commit message will be generated without making the actual commit, there is a `-dry-run` flag that can be passed to the command:
 ```shell

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,17 +27,17 @@ Simple CLI tool that finds an issue number in the branch and includes it in the 
 Check out the [Makefile](/Makefile) for more commands.
 
 ### Easy Installation With Makefile
-There's a helper command in that can simplify installation:
+There's a helper command that can simplify installation:
 ```shell
 make install
 ```
 1. Make sure you have a compatible version of `Go` installed _(see [go.mod](https://github.com/artem-y/commit/blob/main/go.mod#L3) file)_
 2. Clone the repository
 3. In the root of the repository, run `make install`
-4. (Optional) It will try to install to where it was installed previously. In case this is the first installation, it will be installed in the default Go package directory. If the tool is not visible after instllation, make sure it's directory is included in `PATH`.
+4. _(Optional)_ It will try to install to where the tool was installed previously. In case this is the first installation, it will be installed in the default Go package directory. If the tool is not visible after instllation, make sure its directory is included in `PATH`.
 
 ### Install With Go Tooling
-You can do the steps described above in the [Using Makefile](#install-with-makefile) section, replacing Step 3 (`make build` command) with just a plain Go build command:  
+You can do the steps described above in the [Install With Makefile](#install-with-makefile) section, replacing Step 3 (`make build` command) with just a plain Go build command:  
 ```shell
 go build -o bin/ ./cmd/commit
 ```
@@ -45,7 +45,7 @@ Or you can skip even those steps and use `go install` command:
 ```shell
 go install -ldflags "-s -w" ./cmd/commit
 ```
-This will install the executable in the default Go package directory. If the tool is not visible after the installation, make sure it's directory is included in `PATH`.
+This will install the executable in the default Go package directory. If the tool is not visible after installation, make sure its directory is included in `PATH`.
 
 For more information, see [Tutorial: Compile and install the application](https://go.dev/doc/tutorial/compile-install) 
 ## Usage

--- a/e2e.sh
+++ b/e2e.sh
@@ -22,6 +22,12 @@ yellow() {
     echo "\033[0;33m$1\033[0m"
 }
 
+setup_global_git_config() {
+    git config --global init.defaultBranch main
+    git config --global user.name "GitHub Actions CI Runner"
+    git config --global user.email "--"
+}
+
 setup_test_repository() { 
     # Create a new directory
     mkdir testdir && \
@@ -53,6 +59,7 @@ pass_test() {
 # MARK: - Test Cases
 
 test_commit_from_current_directory_without_config() {
+    FUNCNAME="test_commit_from_current_directory_without_config"
     start_test $FUNCNAME
 
     setup_test_repository &&\
@@ -80,6 +87,7 @@ test_commit_from_current_directory_without_config() {
 }
 
 test_use_config_from_current_directory() {
+    FUNCNAME="test_use_config_from_current_directory"
     start_test $FUNCNAME
 
     setup_test_repository &&\
@@ -118,6 +126,7 @@ test_use_config_from_current_directory() {
 }
 
 test_commit_from_subdirectory() {
+    FUNCNAME="test_commit_from_subdirectory"
     start_test $FUNCNAME
 
     setup_test_repository &&\
@@ -162,6 +171,7 @@ test_commit_from_subdirectory() {
 }
 
 test_set_correct_author() {
+    FUNCNAME="test_set_correct_author"
     start_test $FUNCNAME
 
     EXPECTED_AUTHOR_NAME="John Doe"
@@ -212,6 +222,7 @@ test_set_correct_author() {
 # MARK: - Run Tests
 
 build_if_needed
+setup_global_git_config
 
 test_commit_from_current_directory_without_config
 test_use_config_from_current_directory

--- a/e2e.sh
+++ b/e2e.sh
@@ -1,0 +1,219 @@
+#!/bin/sh
+
+# MARK: - Setup
+
+function build_if_needed() {
+    # Check if there already is a pre-built executable
+    if [ ! -f ./bin/commit ]; then
+        # Build the executable, exit if build fails
+        make build || exit 1
+    fi
+}
+
+function red() {
+    echo "\033[0;31m$1\033[0m"
+}
+
+function green() {
+    echo "\033[0;32m$1\033[0m"
+}
+
+function yellow() {
+    echo "\033[0;33m$1\033[0m"
+}
+
+function setup_test_repository() { 
+    # Create a new directory
+    mkdir testdir && \
+    cd testdir && \
+
+    # Initialize a new repository
+    git init && \
+    touch file && git add file && git commit -m "Initial commit"
+}
+
+function start_test() {
+    echo ""
+    echo $(yellow "TEST: $1")
+}
+
+function fail_test() {
+    echo $(red "FAIL: $1")
+        cd ..
+        rm -rf testdir
+        exit 1
+}
+
+function pass_test() {
+    echo $(green "PASS: $1")
+        cd ..
+        rm -rf testdir
+}
+
+# MARK: - Test Cases
+
+function test_commit_from_current_directory_without_config() {
+    start_test $FUNCNAME
+
+    setup_test_repository &&\
+    git checkout -b 1-initial-branch && \
+
+    # Create a new file
+    echo "Hello, World!" > hello.txt && \
+
+    git add hello.txt && \
+
+    # Commit the file
+    ../bin/commit "Hello, git!"
+
+    # Check if the commit was successful
+    if [ $? -ne 0 ]; then
+        fail_test $FUNCNAME
+    fi
+
+    # Check if the commit message is correct
+    if [ "$(git log -1 --pretty=%B)" != '#1: Hello, git!' ]; then
+        fail_test $FUNCNAME
+    fi
+
+    pass_test $FUNCNAME
+}
+
+function test_use_config_from_current_directory() {
+    start_test $FUNCNAME
+
+    setup_test_repository &&\
+    git checkout -b feature/DEV-38-setup-new-module && \
+
+    # Write a config file
+    echo '
+    { 
+        "issueRegex": "DEV-[0-9]+",
+        "outputIssuePrefix": "[",
+        "outputIssueSuffix": "]",
+        "outputStringPrefix": "",
+        "outputStringSuffix": " "
+    }
+    ' > .commit.json && \
+
+    # Create a new file
+    echo "Hello, World!" > hello && \
+
+    git add hello && \
+
+    # Commit the file
+    ../bin/commit "Add a new file"
+
+    # Check if the commit was successful
+    if [ $? -ne 0 ]; then
+        fail_test $FUNCNAME
+    fi
+
+    # Check if the commit message is correct
+    if [ "$(git log -1 --pretty=%B)" != '[DEV-38] Add a new file' ]; then
+        fail_test $FUNCNAME
+    fi
+
+    pass_test $FUNCNAME
+}
+
+function test_commit_from_subdirectory() {
+    start_test $FUNCNAME
+
+    setup_test_repository &&\
+    git checkout -b prepare-for-cfg13 && \
+
+    # Write a config file
+    echo '
+    { 
+        "issueRegex": "cfg[0-9]+",
+        "outputIssuePrefix": "",
+        "outputIssueSuffix": "",
+        "outputStringPrefix": "(",
+        "outputStringSuffix": ") "
+    }
+    ' > .commit.json && \
+
+    # Create a new file
+    echo "Hello, World!" > hello.world && \
+
+    git add hello.world && \
+
+    # Create a new subdirectory
+    mkdir testsubdir && cd testsubdir && \
+
+    # Commit the file
+    ../../bin/commit "Do something very useful"
+
+    # Check if the commit was successful
+    if [ $? -ne 0 ]; then
+        cd ..
+        fail_test $FUNCNAME
+    fi
+
+    # Check if the commit message is correct
+    if [ "$(git log -1 --pretty=%B)" != '(cfg13) Do something very useful' ]; then
+        cd ..
+        fail_test $FUNCNAME
+    fi
+
+    cd ..
+    pass_test $FUNCNAME
+}
+
+function test_set_correct_author() {
+    start_test $FUNCNAME
+
+    EXPECTED_AUTHOR_NAME="John Doe"
+    EXPECTED_EMAIL="johntheprogrammer@commit.commit"
+
+    setup_test_repository &&\
+    git config --local user.name "${EXPECTED_AUTHOR_NAME}" && \
+    git config --local user.email "${EXPECTED_EMAIL}" && \
+    git checkout -b 1-initial-branch && \
+
+    # Create a new file
+    echo "Hello, World!" > hello.txt && \
+
+    git add hello.txt && \
+
+    # Commit the file
+    ../bin/commit "Hello, git!"
+
+    # Check if the commit was successful
+    if [ $? -ne 0 ]; then
+        fail_test $FUNCNAME
+    fi
+
+    # Check if the commit message is correct
+    if [ "$(git log -1 --pretty=%B)" != '#1: Hello, git!' ]; then
+        fail_test $FUNCNAME
+    fi
+
+    # Check if the commit author name is correct
+    ACTUAL_AUTHOR_NAME=$(git log -1 --pretty=%an)
+    echo "Author name: ${ACTUAL_AUTHOR_NAME}"
+    if [ "${ACTUAL_AUTHOR_NAME}" != "${EXPECTED_AUTHOR_NAME}" ]; then
+        echo "Incorrect author name: expected ${EXPECTED_AUTHOR_NAME}, got ${ACTUAL_AUTHOR_NAME}"
+        fail_test $FUNCNAME
+    fi
+
+    # Check if the commit author email is correct
+    ACTUAL_EMAIL=$(git log -1 --pretty=%ae)
+    echo "Author email: ${ACTUAL_EMAIL}"
+    if [ "${ACTUAL_EMAIL}" != "${EXPECTED_EMAIL}" ]; then
+        echo "Incorrect author email: expected ${EXPECTED_EMAIL}, got ${ACTUAL_EMAIL}"
+        fail_test $FUNCNAME
+    fi
+
+    pass_test $FUNCNAME
+}
+
+# MARK: - Run Tests
+
+build_if_needed
+
+test_commit_from_current_directory_without_config
+test_use_config_from_current_directory
+test_commit_from_subdirectory
+test_set_correct_author

--- a/e2e.sh
+++ b/e2e.sh
@@ -2,7 +2,7 @@
 
 # MARK: - Setup
 
-function build_if_needed() {
+build_if_needed() {
     # Check if there already is a pre-built executable
     if [ ! -f ./bin/commit ]; then
         # Build the executable, exit if build fails
@@ -10,19 +10,19 @@ function build_if_needed() {
     fi
 }
 
-function red() {
+red() {
     echo "\033[0;31m$1\033[0m"
 }
 
-function green() {
+green() {
     echo "\033[0;32m$1\033[0m"
 }
 
-function yellow() {
+yellow() {
     echo "\033[0;33m$1\033[0m"
 }
 
-function setup_test_repository() { 
+setup_test_repository() { 
     # Create a new directory
     mkdir testdir && \
     cd testdir && \
@@ -32,19 +32,19 @@ function setup_test_repository() {
     touch file && git add file && git commit -m "Initial commit"
 }
 
-function start_test() {
+start_test() {
     echo ""
     echo $(yellow "TEST: $1")
 }
 
-function fail_test() {
+fail_test() {
     echo $(red "FAIL: $1")
         cd ..
         rm -rf testdir
         exit 1
 }
 
-function pass_test() {
+pass_test() {
     echo $(green "PASS: $1")
         cd ..
         rm -rf testdir
@@ -52,7 +52,7 @@ function pass_test() {
 
 # MARK: - Test Cases
 
-function test_commit_from_current_directory_without_config() {
+test_commit_from_current_directory_without_config() {
     start_test $FUNCNAME
 
     setup_test_repository &&\
@@ -79,7 +79,7 @@ function test_commit_from_current_directory_without_config() {
     pass_test $FUNCNAME
 }
 
-function test_use_config_from_current_directory() {
+test_use_config_from_current_directory() {
     start_test $FUNCNAME
 
     setup_test_repository &&\
@@ -117,7 +117,7 @@ function test_use_config_from_current_directory() {
     pass_test $FUNCNAME
 }
 
-function test_commit_from_subdirectory() {
+test_commit_from_subdirectory() {
     start_test $FUNCNAME
 
     setup_test_repository &&\
@@ -161,7 +161,7 @@ function test_commit_from_subdirectory() {
     pass_test $FUNCNAME
 }
 
-function test_set_correct_author() {
+test_set_correct_author() {
     start_test $FUNCNAME
 
     EXPECTED_AUTHOR_NAME="John Doe"


### PR DESCRIPTION
In this PR:
- wrote a few end-to-end tests (`e2e.sh` file) to cover a few happy paths that make sure the tool works in an actual repository
- added another one more step to run the end-to-end tests
- bumped `setup-go` action to a newer `v5` version
- added an easier installation command, `make install`
- updated README, described more installation options and mentioned the newly added tests