### PR TITLE
Print out correct path in the installation message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ install:
 	@INSTALLATION_PATH=$$(which commit) ; \
 	if [ -z "$${INSTALLATION_PATH}" ]; then \
 		go install -ldflags "-s -w" ./cmd/commit/ ; \
+		INSTALLATION_PATH=$$(which commit) ; \
 	else \
 		go build -ldflags "-s -w" -o bin/ ./cmd/commit ; \
 		INSTALLATION_DIR=$$(dirname "$${INSTALLATION_PATH}") ; \


### PR DESCRIPTION
In this PR:
- quick fix to output the path to where the tool was installed with `make install`, it was empty when installing for the first time