### PR TITLE
Validate issue regex

### DIFF
--- a/e2e.sh
+++ b/e2e.sh
@@ -219,6 +219,40 @@ test_set_correct_author() {
     pass_test $TESTNAME
 }
 
+test_use_config_with_empty_regex() {
+    TESTNAME="test_use_config_with_empty_regex"
+    start_test $TESTNAME
+
+    setup_test_repository &&\
+    git checkout -b feature/WIP-88-add-privacy-manifest && \
+
+    # Write a config file
+    echo '
+    { 
+        "issueRegex": ""
+    }
+    ' > .commit.json && \
+
+    # Create a new file
+    echo "Hello, World!" > hello && \
+
+    git add hello && \
+
+    # Commit the file
+    echo "Expecting exit with error..." && \
+    ../bin/commit "Add missing privacy manifest"
+
+    # Check if the commit was successful
+    if [ $? -eq 0 ]; then
+        echo "Expected exit with error, but the commit was successful"
+        fail_test $TESTNAME
+    fi 
+
+    echo "Failed with error as expected!"
+    pass_test $TESTNAME
+
+}
+
 # MARK: - Run Tests
 
 build_if_needed
@@ -228,3 +262,4 @@ test_commit_from_current_directory_without_config
 test_use_config_from_current_directory
 test_commit_from_subdirectory
 test_set_correct_author
+test_use_config_with_empty_regex

--- a/e2e.sh
+++ b/e2e.sh
@@ -59,8 +59,8 @@ pass_test() {
 # MARK: - Test Cases
 
 test_commit_from_current_directory_without_config() {
-    FUNCNAME="test_commit_from_current_directory_without_config"
-    start_test $FUNCNAME
+    TESTNAME="test_commit_from_current_directory_without_config"
+    start_test $TESTNAME
 
     setup_test_repository &&\
     git checkout -b 1-initial-branch && \
@@ -75,20 +75,20 @@ test_commit_from_current_directory_without_config() {
 
     # Check if the commit was successful
     if [ $? -ne 0 ]; then
-        fail_test $FUNCNAME
+        fail_test $TESTNAME
     fi
 
     # Check if the commit message is correct
     if [ "$(git log -1 --pretty=%B)" != '#1: Hello, git!' ]; then
-        fail_test $FUNCNAME
+        fail_test $TESTNAME
     fi
 
-    pass_test $FUNCNAME
+    pass_test $TESTNAME
 }
 
 test_use_config_from_current_directory() {
-    FUNCNAME="test_use_config_from_current_directory"
-    start_test $FUNCNAME
+    TESTNAME="test_use_config_from_current_directory"
+    start_test $TESTNAME
 
     setup_test_repository &&\
     git checkout -b feature/DEV-38-setup-new-module && \
@@ -114,20 +114,20 @@ test_use_config_from_current_directory() {
 
     # Check if the commit was successful
     if [ $? -ne 0 ]; then
-        fail_test $FUNCNAME
+        fail_test $TESTNAME
     fi
 
     # Check if the commit message is correct
     if [ "$(git log -1 --pretty=%B)" != '[DEV-38] Add a new file' ]; then
-        fail_test $FUNCNAME
+        fail_test $TESTNAME
     fi
 
-    pass_test $FUNCNAME
+    pass_test $TESTNAME
 }
 
 test_commit_from_subdirectory() {
-    FUNCNAME="test_commit_from_subdirectory"
-    start_test $FUNCNAME
+    TESTNAME="test_commit_from_subdirectory"
+    start_test $TESTNAME
 
     setup_test_repository &&\
     git checkout -b prepare-for-cfg13 && \
@@ -157,22 +157,22 @@ test_commit_from_subdirectory() {
     # Check if the commit was successful
     if [ $? -ne 0 ]; then
         cd ..
-        fail_test $FUNCNAME
+        fail_test $TESTNAME
     fi
 
     # Check if the commit message is correct
     if [ "$(git log -1 --pretty=%B)" != '(cfg13) Do something very useful' ]; then
         cd ..
-        fail_test $FUNCNAME
+        fail_test $TESTNAME
     fi
 
     cd ..
-    pass_test $FUNCNAME
+    pass_test $TESTNAME
 }
 
 test_set_correct_author() {
-    FUNCNAME="test_set_correct_author"
-    start_test $FUNCNAME
+    TESTNAME="test_set_correct_author"
+    start_test $TESTNAME
 
     EXPECTED_AUTHOR_NAME="John Doe"
     EXPECTED_EMAIL="johntheprogrammer@commit.commit"
@@ -192,12 +192,12 @@ test_set_correct_author() {
 
     # Check if the commit was successful
     if [ $? -ne 0 ]; then
-        fail_test $FUNCNAME
+        fail_test $TESTNAME
     fi
 
     # Check if the commit message is correct
     if [ "$(git log -1 --pretty=%B)" != '#1: Hello, git!' ]; then
-        fail_test $FUNCNAME
+        fail_test $TESTNAME
     fi
 
     # Check if the commit author name is correct
@@ -205,7 +205,7 @@ test_set_correct_author() {
     echo "Author name: ${ACTUAL_AUTHOR_NAME}"
     if [ "${ACTUAL_AUTHOR_NAME}" != "${EXPECTED_AUTHOR_NAME}" ]; then
         echo "Incorrect author name: expected ${EXPECTED_AUTHOR_NAME}, got ${ACTUAL_AUTHOR_NAME}"
-        fail_test $FUNCNAME
+        fail_test $TESTNAME
     fi
 
     # Check if the commit author email is correct
@@ -213,10 +213,10 @@ test_set_correct_author() {
     echo "Author email: ${ACTUAL_EMAIL}"
     if [ "${ACTUAL_EMAIL}" != "${EXPECTED_EMAIL}" ]; then
         echo "Incorrect author email: expected ${EXPECTED_EMAIL}, got ${ACTUAL_EMAIL}"
-        fail_test $FUNCNAME
+        fail_test $TESTNAME
     fi
 
-    pass_test $FUNCNAME
+    pass_test $TESTNAME
 }
 
 # MARK: - Run Tests

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
+	"regexp"
 
 	"github.com/artem-y/commit/internal/helpers"
 )
@@ -44,6 +46,10 @@ func ReadCommitConfig(fileReader FileReading, configFilePath string) (CommitConf
 
 	cfg := makeConfig(cfgDto)
 
+	if err := validateRegex(cfg.IssueRegex); err != nil {
+		return CommitConfig{}, err
+	}
+
 	return cfg, nil
 }
 
@@ -84,4 +90,14 @@ func makeConfig(cfgDto commitConfigDTO) CommitConfig {
 	}
 
 	return cfg
+}
+
+// Validate the issue regex
+func validateRegex(rawString string) error {
+	if rawString == "" {
+		return errors.New("Issue regex can't be empty. Please update the config file.")
+	}
+
+	_, err := regexp.Compile(rawString)
+	return err
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -154,6 +154,22 @@ func Test_ReadCommitConfig_WhenIssueRegexIsEmpty_ReturnsError(t *testing.T) {
 
 }
 
+func Test_ReadCommitConfig_WhenIssueRegexIsInvalid_ReturnsError(t *testing.T) {
+	// Arrange
+	var mock *mocks.FileReadingMock = &mocks.FileReadingMock{}
+	configJson := "{\"issueRegex\":\"(123\"}"
+	mock.Results.ReadFile.Success = []byte(configJson)
+
+	// Act
+	_, err := config.ReadCommitConfig(mock, "some/path")
+
+	// Assert
+	if err == nil {
+		t.Error("Expected an error, got `nil`")
+	}
+
+}
+
 func Test_MakeDefaultConfig_CreatesConfigWithDefaultValues(t *testing.T) {
 	// Arrange
 	expectedConfig := config.CommitConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -138,6 +138,22 @@ func Test_ReadCommitConfig_WhenOnlyRegexInConfix_ReturnsConfigWithRegex(t *testi
 	}
 }
 
+func Test_ReadCommitConfig_WhenIssueRegexIsEmpty_ReturnsError(t *testing.T) {
+	// Arrange
+	var mock *mocks.FileReadingMock = &mocks.FileReadingMock{}
+	configJson := "{\"issueRegex\":\"\"}"
+	mock.Results.ReadFile.Success = []byte(configJson)
+
+	// Act
+	_, err := config.ReadCommitConfig(mock, "some/path")
+
+	// Assert
+	if err == nil {
+		t.Error("Expected an error, got `nil`")
+	}
+
+}
+
 func Test_MakeDefaultConfig_CreatesConfigWithDefaultValues(t *testing.T) {
 	// Arrange
 	expectedConfig := config.CommitConfig{

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-    "github.com/artem-y/commit/internal/helpers"
+	"github.com/artem-y/commit/internal/helpers"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"


### PR DESCRIPTION
In this PR:
- added a check for the `issueRegex` in the config file being non-empty and valid
- wrote unit tests for this check
- fixed collision with the default `$FUNCNAME` variable that was preventing the tests from running correctly in some shells
- added a new end-to-end test for the empty `issueRegex` case