### PR TITLE
Prevent resetting global git config in tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -93,7 +93,7 @@ For example, the branch named `add-tests-for-CR-127-and-CR-131-features`, the is
 ## Testing
 So far only the core parts of the logic are covered with tests, but I will be adding more in the future.  
 To run the unit tests, use the `make test` or `go test -v ./...` commands.  
-There also are a few end-to-end tests that will run in the CI pipeline to make sure the tool actually works as expected with a real repository. I do not advise running those often manually, since they can potentially execute destructive commands.
+There also are a few end-to-end tests that will run in the CI pipeline to make sure the tool actually works as expected with a real repository. I do not advise running those often manually, since they can potentially execute destructive commands. For example, there is at least one change the tests will try to apply to the global git setup, which is the setting of the default init branch to "main".
 ### Debug
 To check what commit message will be generated without making the actual commit, there is a `-dry-run` flag that can be passed to the command:
 ```shell

--- a/e2e.sh
+++ b/e2e.sh
@@ -28,7 +28,7 @@ setup_test_repository() {
     cd testdir && \
 
     # Initialize a new repository
-    git config --local init.defaultBranch main && \
+    git config --global init.defaultBranch main && \
     git init && \
     # Set up local git config inside the new directory
     git config --local user.name "GitHub Actions CI Runner" && \

--- a/e2e.sh
+++ b/e2e.sh
@@ -22,12 +22,6 @@ yellow() {
     echo "\033[0;33m$1\033[0m"
 }
 
-setup_local_git_config() {
-    git config --local init.defaultBranch main
-    git config --local user.name "GitHub Actions CI Runner"
-    git config --local user.email "--"
-}
-
 setup_test_repository() { 
     # Create a new directory
     mkdir testdir && \
@@ -35,6 +29,10 @@ setup_test_repository() {
 
     # Initialize a new repository
     git init && \
+    # Set up local git config inside the new directory
+    git config --local init.defaultBranch main && \
+    git config --local user.name "GitHub Actions CI Runner" && \
+    git config --local user.email "--" && \
     touch file && git add file && git commit -m "Initial commit"
 }
 
@@ -256,7 +254,6 @@ test_use_config_with_empty_regex() {
 # MARK: - Run Tests
 
 build_if_needed
-setup_local_git_config
 
 test_commit_from_current_directory_without_config
 test_use_config_from_current_directory

--- a/e2e.sh
+++ b/e2e.sh
@@ -22,10 +22,10 @@ yellow() {
     echo "\033[0;33m$1\033[0m"
 }
 
-setup_global_git_config() {
-    git config --global init.defaultBranch main
-    git config --global user.name "GitHub Actions CI Runner"
-    git config --global user.email "--"
+setup_local_git_config() {
+    git config --local init.defaultBranch main
+    git config --local user.name "GitHub Actions CI Runner"
+    git config --local user.email "--"
 }
 
 setup_test_repository() { 

--- a/e2e.sh
+++ b/e2e.sh
@@ -28,9 +28,9 @@ setup_test_repository() {
     cd testdir && \
 
     # Initialize a new repository
+    git config --local init.defaultBranch main && \
     git init && \
     # Set up local git config inside the new directory
-    git config --local init.defaultBranch main && \
     git config --local user.name "GitHub Actions CI Runner" && \
     git config --local user.email "--" && \
     touch file && git add file && git commit -m "Initial commit"

--- a/e2e.sh
+++ b/e2e.sh
@@ -256,7 +256,7 @@ test_use_config_with_empty_regex() {
 # MARK: - Run Tests
 
 build_if_needed
-setup_global_git_config
+setup_local_git_config
 
 test_commit_from_current_directory_without_config
 test_use_config_from_current_directory


### PR DESCRIPTION
In this PR:
- fixed unwanted reset of global config when running on local machine from end-to-end tests
- updated README to mention a real example of potentially unwanted change that end-to-end tests can apply