### PR TITLE
Handle detached HEAD and initial commit

### DIFF
--- a/cmd/commit/main.go
+++ b/cmd/commit/main.go
@@ -55,11 +55,11 @@ func main() {
 
 	fileReader := config.FileReader{}
 
-	headFile, _ := fileReader.ReadFile(headFilePath)
-
 	// Read current HEAD from file
+	headFile, _ := fileReader.ReadFile(headFilePath)
 	headFileText := string(headFile)
 
+	// If there is a branch name in the HEAD file, modify the commit message
 	if strings.HasPrefix(headFileText, helpers.HEAD_REF_PREFIX) {
 		branchName := strings.TrimPrefix(
 			headFileText,

--- a/internal/helpers/constants.go
+++ b/internal/helpers/constants.go
@@ -7,4 +7,5 @@ const (
 	DEFAULT_OUTPUT_ISSUE_SUFFIX  = ""
 	DEFAULT_OUTPUT_STRING_PREFIX = ""
 	DEFAULT_OUTPUT_STRING_SUFFIX = ": "
+	HEAD_REF_PREFIX              = "ref: refs/heads/"
 )


### PR DESCRIPTION
In this PR:
- allowed making the commit when the HEAD is detached or when it's an initial commit
- for the initial commit, made sure the branch name is picked up correctly from the `.git/HEAD` file
- added a new `test_commit_with_detached_head` e2e test for the detached HEAD case
- removed extra step of creating initial commit for the most end-to-end tests, since it's no longer needed