### PR TITLE
Update default config behaviour

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ The result: for example, if the branch name is `312-improve-stability-of-the-cor
 > #312: Refactor core service initialization logic
 ### Configuration
 By default, the tool recognizes the pattern suggested by GitHub when auto-generating branches, when issue numbers are just digits: `28-update-documentation` for the issue  `#28`.  
-But this can be changed by setting different values in a `.commit.json` file at the root of your repository:  
+But this can be changed by providing a `.commit.json` file with different values at the root of your repository:  
 ```json
 {  
     "issueRegex": "ABC-[0-9]+", 
@@ -79,8 +79,7 @@ The structure of the resulting commit message is as follows:
 ```
 <outputStringPrefix><outputIssuePrefix><issueRegex><outputIssueSuffix>, <outputIssuePrefix><issueRegex><outputIssueSuffix><outputStringSuffix> <commit message>
 ```
-If the `.commit.json` file is not included, the tool will just fall back to its default settings (GitHub style issues).  
-Same will happen for any of the settings that is not included in the config json. See the default values in [constants.go](/internal/helpers/constants.go) file.
+If the `.commit.json` file is not included, the tool will just fall back to its default settings (GitHub style issues). See the default values in [constants.go](/internal/helpers/constants.go) file.
 ### Custom Config Path
 If you don't want to include the `.commit.json` file at the root of your repository, path to the config file can be passed with a `-config-path` flag like this (linux/macOS shell example):
 ```shell

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,9 +67,12 @@ func MakeDefaultConfig() CommitConfig {
 // MARK: - Private
 
 func makeConfig(cfgDto commitConfigDTO) CommitConfig {
-	cfg := MakeDefaultConfig()
+	cfg := CommitConfig{}
 
 	if cfgDto.IssueRegex != nil {
+		if *cfgDto.IssueRegex == "" {
+			return cfg
+		}
 		cfg.IssueRegex = *cfgDto.IssueRegex
 	}
 
@@ -87,6 +90,10 @@ func makeConfig(cfgDto commitConfigDTO) CommitConfig {
 
 	if cfgDto.OutputStringSuffix != nil {
 		cfg.OutputStringSuffix = *cfgDto.OutputStringSuffix
+	}
+
+	if (cfg == CommitConfig{}) {
+		return MakeDefaultConfig()
 	}
 
 	return cfg

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,7 +110,7 @@ func Test_ReadCommitConfig_WhenOnlyRegexInConfix_ReturnsConfigWithRegex(t *testi
 	configJson := fmt.Sprintf("{\"issueRegex\":\"%s\"}", expectedRegex)
 	mock.Results.ReadFile.Success = []byte(configJson)
 
-	expectedConfig := config.MakeDefaultConfig()
+	expectedConfig := config.CommitConfig{}
 	expectedConfig.IssueRegex = expectedRegex
 
 	// Act


### PR DESCRIPTION
## In this PR:
- updated the default config behavior
- updated unit test to reflect the new expected result
- updated the README file to keep it up to date with this change

## Details:  
Previously, when config had omitted values, the command was replacing each of them with a default value.  
For example, if the `.commit.json` file contained only the issue regex
```json
{  
    "issueRegex": "ABC-[0-9]+" 
}
```
the resulting config would be as follows:
```json
{  
    "issueRegex": "ABC-[0-9]+", 
    "outputIssuePrefix": "#",
    "outputIssueSuffix": "",
    "outputStringPrefix": "",
    "outputStringSuffix": ": ",
}
```
Note that `outputIssuePrefix` and `outputStringSuffix` have default values here that were not originally specified by the user, even though they provided the `.commit.json` config file.  

While this was the default behavior I wanted at the time of initial development of the tool, after using it for a while and talking to other users, I think having these values set by default is counterintuitive. From now on, if the same content was provided in the config file, the missing properties will default to empty strings.  

However, if no config file was specified, the tool will still default to the GitHub issue style with simple output formatting.