### PR TITLE
Support commits from a linked worktree

### DIFF
--- a/cmd/commit/main.go
+++ b/cmd/commit/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/artem-y/commit/internal/config"
@@ -14,6 +13,7 @@ import (
 	"github.com/artem-y/commit/internal/user"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
@@ -47,25 +47,17 @@ func main() {
 		)
 	}
 
-	headFilePath := filepath.Join(
-		worktree.Filesystem.Root(),
-		".git",
-		"HEAD",
-	)
+	head, err := repo.Reference(plumbing.HEAD, false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, helpers.Red("Failed to read HEAD: %v\n"), err)
+		os.Exit(1)
+	}
 
-	fileReader := config.FileReader{}
+	// If HEAD points to branch, modify the commit message
+	if head.Type() == plumbing.SymbolicReference && head.Target().IsBranch() {
+		branchName := head.Target().Short()
 
-	// Read current HEAD from file
-	headFile, _ := fileReader.ReadFile(headFilePath)
-	headFileText := string(headFile)
-
-	// If there is a branch name in the HEAD file, modify the commit message
-	if strings.HasPrefix(headFileText, helpers.HEAD_REF_PREFIX) {
-		branchName := strings.TrimPrefix(
-			headFileText,
-			helpers.HEAD_REF_PREFIX,
-		)
-
+		fileReader := config.FileReader{}
 		cfg, err := config.ReadCommitConfig(fileReader, configFilePath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, helpers.Red("Failed to read config: %v\n"), err)
@@ -101,8 +93,10 @@ func getCommitMessage() string {
 
 // Opens the current repository
 func openRepo() *git.Repository {
-
-	options := git.PlainOpenOptions{DetectDotGit: true}
+	options := git.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
+	}
 
 	repo, err := git.PlainOpenWithOptions(".", &options)
 	if err != nil {

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,8 +60,8 @@ The result: for example, if the branch name is `312-improve-stability-of-the-cor
 By default, the tool recognizes the pattern suggested by GitHub when auto-generating branches, when issue numbers are just digits: `28-update-documentation` for the issue  `#28`.  
 But this can be changed by providing a `.commit.json` file with different values at the root of your repository:  
 ```json
-{  
-    "issueRegex": "ABC-[0-9]+", 
+{
+    "issueRegex": "ABC-[0-9]+",
     "outputIssuePrefix": "#",
     "outputIssueSuffix": "",
     "outputStringPrefix": "",

--- a/e2e.sh
+++ b/e2e.sh
@@ -327,7 +327,7 @@ test_commit_from_another_worktree() {
     git add hello.worktree && \
 
     # Commit the file
-    ../bin/commit "Commited from another worktree"
+    ../bin/commit "Committed from another worktree"
 
     # Check if the commit was successful
     if [ $? -ne 0 ]; then
@@ -336,7 +336,7 @@ test_commit_from_another_worktree() {
     fi
 
     # Check if the commit message is correct
-    if [ "$(git log -1 --pretty=%B)" != '#333: Commited from another worktree' ]; then
+    if [ "$(git log -1 --pretty=%B)" != '#333: Committed from another worktree' ]; then
         remove_worktree ../worktree_copy
         fail_test $TESTNAME
     fi

--- a/e2e.sh
+++ b/e2e.sh
@@ -35,6 +35,12 @@ setup_test_repository() {
     git config --local user.email "--"
 }
 
+remove_worktree() {
+    cd ../testdir && \
+    git worktree remove $1 && \
+    rm -rf $1
+}
+
 start_test() {
     echo ""
     echo $(yellow "TEST: $1")
@@ -300,6 +306,45 @@ test_commit_with_detached_head() {
     pass_test $TESTNAME
 }
 
+test_commit_from_another_worktree() {
+    TESTNAME="test_commit_from_another_worktree"
+    start_test $TESTNAME
+
+    setup_test_repository &&\
+    git checkout -b main && \
+
+    # Create the initial commit
+    echo "Hello, main!" > hello4 && \
+    git add hello4 && \
+    ../bin/commit "Initial commit" && \
+
+    # Add a worktree on a new branch
+    git worktree add ../worktree_copy -b feature/333-additional-work && \
+    cd ../worktree_copy && \
+
+    # Create a new file
+    echo "Hello worktree!" > hello.worktree && \
+    git add hello.worktree && \
+
+    # Commit the file
+    ../bin/commit "Commited from another worktree"
+
+    # Check if the commit was successful
+    if [ $? -ne 0 ]; then
+        remove_worktree ../worktree_copy
+        fail_test $TESTNAME
+    fi
+
+    # Check if the commit message is correct
+    if [ "$(git log -1 --pretty=%B)" != '#333: Commited from another worktree' ]; then
+        remove_worktree ../worktree_copy
+        fail_test $TESTNAME
+    fi
+
+    remove_worktree ../worktree_copy
+    pass_test $TESTNAME
+}
+
 # MARK: - Run Tests
 
 build_if_needed
@@ -310,3 +355,4 @@ test_commit_from_subdirectory
 test_set_correct_author
 test_use_config_with_empty_regex
 test_commit_with_detached_head
+test_commit_from_another_worktree

--- a/e2e.sh
+++ b/e2e.sh
@@ -311,7 +311,7 @@ test_commit_from_another_worktree() {
     start_test $TESTNAME
 
     setup_test_repository &&\
-    git checkout -b main && \
+    git checkout -b initial-branch && \
 
     # Create the initial commit
     echo "Hello, main!" > hello4 && \

--- a/e2e.sh
+++ b/e2e.sh
@@ -22,7 +22,7 @@ yellow() {
     echo "\033[0;33m$1\033[0m"
 }
 
-setup_test_repository() { 
+setup_test_repository() {
     # Create a new directory
     mkdir testdir && \
     cd testdir && \
@@ -98,7 +98,7 @@ test_use_config_from_current_directory() {
 
     # Write a config file
     echo '
-    { 
+    {
         "issueRegex": "DEV-[0-9]+",
         "outputIssuePrefix": "[",
         "outputIssueSuffix": "]",
@@ -137,7 +137,7 @@ test_commit_from_subdirectory() {
 
     # Write a config file
     echo '
-    { 
+    {
         "issueRegex": "cfg[0-9]+",
         "outputIssuePrefix": "",
         "outputIssueSuffix": "",
@@ -231,7 +231,7 @@ test_use_config_with_empty_regex() {
 
     # Write a config file
     echo '
-    { 
+    {
         "issueRegex": ""
     }
     ' > .commit.json && \
@@ -266,7 +266,7 @@ test_commit_with_detached_head() {
 
     # Write a config file
     echo '
-    { 
+    {
         "issueRegex": "DEV-[0-9]+",
         "outputIssuePrefix": "",
         "outputIssueSuffix": "",

--- a/internal/helpers/constants.go
+++ b/internal/helpers/constants.go
@@ -7,5 +7,4 @@ const (
 	DEFAULT_OUTPUT_ISSUE_SUFFIX  = ""
 	DEFAULT_OUTPUT_STRING_PREFIX = ""
 	DEFAULT_OUTPUT_STRING_SUFFIX = ": "
-	HEAD_REF_PREFIX              = "ref: refs/heads/"
 )


### PR DESCRIPTION
In this PR:
- updated the tool to support making commits from linked worktree
- added a test for a scenario when commit is being made from a linked worktree
- cleaned up extra whitespaces